### PR TITLE
Pass identifier string when creating callout node

### DIFF
--- a/MapboxARKit/Annotation.swift
+++ b/MapboxARKit/Annotation.swift
@@ -5,10 +5,11 @@ public class Annotation: NSObject {
     public var location: CLLocation
     public var calloutImage: UIImage?
     public var anchor: MBARAnchor?
-    
-    public init(location: CLLocation, calloutImage: UIImage?) {
+    public var identifier: String
+    public init(location: CLLocation, calloutImage: UIImage?, identifier: String) {
         self.location = location
         self.calloutImage = calloutImage
+        self.identifier = identifier
     }
     
 }

--- a/MapboxARKit/AnnotationManager.swift
+++ b/MapboxARKit/AnnotationManager.swift
@@ -102,6 +102,7 @@ extension AnnotationManager: ARSCNViewDelegate {
                         
             if let calloutImage = annotation.calloutImage {
                 let calloutNode = createCalloutNode(with: calloutImage, node: newNode)
+                calloutNode.name = annotation.identifier
                 newNode.addChildNode(calloutNode)
             }
             


### PR DESCRIPTION
Adds .identifier property to Annotation and stores it as the .name property of the associated SCNNode, to facilitate handling user interactions with callout nodes.