### PR TITLE
Fix Podspec source files for Xcode 10 and CocoaPods

### DIFF
--- a/MapboxARKit.podspec
+++ b/MapboxARKit.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxARKit/*"]
+  s.source_files = ["MapboxARKit/*.{h,swift}"]
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
After upgrading to Xcode 10 and using this library with CocoaPods, the Info.plist file inside the source folder is being added to the target, causing a duplicate file error at compile time. This PR removes the plist file from the list of source files.